### PR TITLE
Track NixOS/nixpkgs repo in package lock

### DIFF
--- a/.nixpkgs-version.json
+++ b/.nixpkgs-version.json
@@ -2,9 +2,8 @@
   "nixpkgs": {
     "date": "2020-09-26T18:54:09-07:00",
     "fetchSubmodules": false,
-    "ref": "nixos-unstable",
-    "rev": "84d74ae9c9cbed73274b8e4e00be14688ffc93fe",
-    "sha256": "0ww70kl08rpcsxb9xdx8m48vz41dpss4hh3vvsmswll35l158x0v",
-    "url": "https://github.com/NixOS/nixpkgs-channels"
+    "ref": "nixpkgs-unstable",
+    "rev": "2a058487cb7a50e7650f1657ee0151a19c59ec3b",
+    "url": "https://github.com/NixOS/nixpkgs"
   }
 }


### PR DESCRIPTION
NixOS/nixpkgs-channel has been deprecated
=merge=

Signed-off-by: Jamie Winsor <jamie@onemoregame.com>
